### PR TITLE
Set exported nodes to be hidden by default in feasibility IAEC-344

### DIFF
--- a/html/explore/index.html
+++ b/html/explore/index.html
@@ -588,10 +588,10 @@
             <div class="product_class" style="float:left;">
               <span class="definition" style="font-weight:bold;">Hide exports (Spotlight) </span>
               <div class="btn-group" id="pie_controls" data-toggle="buttons" style="margin-right:20px;">
-                <label class="btn btn-default active" id="spot-off" name="yvar" >
+                <label class="btn btn-default" id="spot-off" name="yvar" >
                   <input type="radio" id="spot_off" name="pie_spot"> Off
                 </label>
-                <label class="btn btn-default" id="spot-on" >
+                <label class="btn btn-default active" id="spot-on" >
                   <input type="radio" id="spot_on" name="pie_spot"> On
                 </label>
               </div>

--- a/media/js/explore/viz_general.js
+++ b/media/js/explore/viz_general.js
@@ -963,7 +963,7 @@ var flat_data,
       .depth("nesting_2")
       .text_format(txt_format)
       .number_format(num_format)
-      .spotlight(false)
+      .spotlight(true)
       .dev(false)
       .font('PT Sans Narrow')
       .click_function(inner_html)


### PR DESCRIPTION
Link: http://beta.atlas.cid.harvard.edu/explore/pie_scatter/export/col/all/show/2015/
![screen shot 2017-05-25 at 4 33 37 pm](https://cloud.githubusercontent.com/assets/161965/26469434/f3a9d05a-4167-11e7-8866-d5a11281a0d2.png)

